### PR TITLE
Wait for change status become `done` and all nameservers return resource record

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ storage:
   path: /path/to/key/storage
 
 challenge_responders:
-  - google-cloud-dns:
+  - google_cloud_dns:
       project_id: my-project-id # GCP Project ID. Be careful it's different from Project Name.
       compute_engine_service_account: true # (pick-one): You can use GCE VM instance scope
       private_key_json_file: /path/to/credential.json # (pick-one) Only JSON key file is supported


### PR DESCRIPTION
This change might fix the `verify_status: invalid` error.
Maybe, sleeping enough time is important.

```
% bundle exec acmesmith authorize foo.example.com
=> Responding challenge dns-01 for foo.example.com in Acmesmith::ChallengeResponders::GoogleCloudDns
 * create_change: TXT "_acme-challenge.foo.example.com.", "2EIxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 * requested change: 59
 * change "59" is still "pending"
 * synced!
=> Checking DNS resource record
 * nameservers: ["ns-cloud-d1.googledomains.com.", "ns-cloud-d2.googledomains.com.", "ns-cloud-d3.googledomains.com.", "ns-cloud-d4.googledomains.com."]
 * [ns-cloud-d1.googledomains.com.] failed: DNS result has no information for _acme-challenge.foo.example.com.
 * [ns-cloud-d1.googledomains.com.] failed: DNS result has no information for _acme-challenge.foo.example.com.
 * [ns-cloud-d1.googledomains.com.] failed: DNS result has no information for _acme-challenge.foo.example.com.
 * [ns-cloud-d1.googledomains.com.] failed: DNS result has no information for _acme-challenge.foo.example.com.
 * [ns-cloud-d1.googledomains.com.] success: ttl=5, data="2EIxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 * [ns-cloud-d2.googledomains.com.] success: ttl=5, data="2EIxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 * [ns-cloud-d3.googledomains.com.] success: ttl=5, data="2EIxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 * [ns-cloud-d4.googledomains.com.] success: ttl=5, data="2EIxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
=> Requesting verification...
 * verify_status: valid
=> Done
```

But still `verify_status: invalid` may happens. We need more sleeping time?

```
% bundle exec acmesmith authorize bar.example.com
=> Responding challenge dns-01 for bar.example.com in Acmesmith::ChallengeResponders::GoogleCloudDns
 * create_change: TXT "_acme-challenge.bar.example.com.", "DdDxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 * requested change: 61
 * change "61" is still "pending"
 * synced!
=> Checking DNS resource record
 * nameservers: ["ns-cloud-d1.googledomains.com.", "ns-cloud-d2.googledomains.com.", "ns-cloud-d3.googledomains.com.", "ns-cloud-d4.googledomains.com."]
 * [ns-cloud-d1.googledomains.com.] success: ttl=5, data="DdDxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 * [ns-cloud-d2.googledomains.com.] failed: DNS result has no information for _acme-challenge.bar.example.com.
 * [ns-cloud-d2.googledomains.com.] failed: DNS result has no information for _acme-challenge.bar.example.com.
 * [ns-cloud-d2.googledomains.com.] failed: DNS result has no information for _acme-challenge.bar.example.com.
 * [ns-cloud-d2.googledomains.com.] failed: DNS result has no information for _acme-challenge.bar.example.com.
 * [ns-cloud-d2.googledomains.com.] success: ttl=5, data="DdDxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 * [ns-cloud-d3.googledomains.com.] success: ttl=5, data="DdDxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 * [ns-cloud-d4.googledomains.com.] failed: DNS result has no information for _acme-challenge.bar.example.com.
 * [ns-cloud-d4.googledomains.com.] failed: DNS result has no information for _acme-challenge.bar.example.com.
 * [ns-cloud-d4.googledomains.com.] success: ttl=5, data="DdDxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
=> Requesting verification...
 * verify_status: invalid
 * verify_status: invalid
 * verify_status: invalid
```
