### PR TITLE
Implemented respond_all, cleanup_all

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Use `google-cloud-dns` challenge responder in your `acmesmith.yml`. General inst
 Write your `tenant_name`, `username`, `password` and `auth_url` in `acmesmith.yml`, or if you don't want to write them down into the file, export these values as the corresponding environment variables `OS_TENANT_NAME`, `OS_USERNAME`, `OS_PASSWORD` and `OS_AUTH_URL`.
 
 ```yaml
-endpoint: https://acme-v01.api.letsencrypt.org/
+directory: https://acme-v02.api.letsencrypt.org/directory
 
 storage:
   type: filesystem

--- a/acmesmith-google-cloud-dns.gemspec
+++ b/acmesmith-google-cloud-dns.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "acmesmith"
+  spec.add_dependency "acmesmith", "~> 2.0"
   spec.add_dependency "google-api-client"
 
   spec.add_development_dependency "bundler", "~> 1.10"

--- a/lib/acmesmith-google-cloud-dns/version.rb
+++ b/lib/acmesmith-google-cloud-dns/version.rb
@@ -1,3 +1,3 @@
 module AcmesmithGoogleCloudDns
-  VERSION = "0.1.1"
+  VERSION = "0.2.0.beta1"
 end

--- a/lib/acmesmith-google-cloud-dns/version.rb
+++ b/lib/acmesmith-google-cloud-dns/version.rb
@@ -1,3 +1,3 @@
 module AcmesmithGoogleCloudDns
-  VERSION = "0.2.0.beta1"
+  VERSION = "0.2.0"
 end

--- a/lib/acmesmith/challenge_responders/google_cloud_dns.rb
+++ b/lib/acmesmith/challenge_responders/google_cloud_dns.rb
@@ -45,9 +45,6 @@ module Acmesmith
         challenges_by_zone_names.each do |zone_name, dcs|
           change = change_for_challenges(zone_name, dcs)
 
-          require 'pry'
-          binding.pry
-
           resp = @api.create_change(@project_id, zone_name, change)
           change_id = resp.id
 
@@ -66,9 +63,6 @@ module Acmesmith
 
         challenges_by_zone_names.each do |zone_name, dcs|
           change = change_for_challenges(zone_name, dcs, for_cleanup: true)
-
-          require 'pry'
-          binding.pry
 
           resp = @api.create_change(@project_id, zone_name, change)
           change_id = resp.id
@@ -183,24 +177,6 @@ module Acmesmith
         }.select{ |rrset|
           rrset.rrdatas != []
         }
-
-        change.deletions.each.with_index do |deletion, idx|
-          puts "change.deletions[#{idx}].name = #{deletion.name.inspect}"
-          puts "change.deletions[#{idx}].type = #{deletion.type.inspect}"
-          puts "change.deletions[#{idx}].ttl = #{deletion.ttl.inspect}"
-          deletion.rrdatas.each.with_index do |rrdata, idx2|
-            puts "change.deletions[#{idx}].rrdatas[#{idx2}] = #{rrdata.inspect}"
-          end
-        end
-
-        change.additions.each.with_index do |addition, idx|
-          puts "change.additions[#{idx}].name = #{addition.name.inspect}"
-          puts "change.additions[#{idx}].type = #{addition.type.inspect}"
-          puts "change.additions[#{idx}].ttl = #{addition.ttl.inspect}"
-          addition.rrdatas.each.with_index do |rrdata, idx2|
-            puts "change.additions[#{idx}].rrdatas[#{idx2}] = #{rrdata.inspect}"
-          end
-        end
 
         change
       end

--- a/lib/acmesmith/challenge_responders/google_cloud_dns.rb
+++ b/lib/acmesmith/challenge_responders/google_cloud_dns.rb
@@ -104,11 +104,11 @@ module Acmesmith
                 resources = dns.getresources(rrset.name, Resolv::DNS::Resource::IN::TXT)
                 actual_rrdatas = resources.map(&:data)
                 if required_rrdatas.subset?(Set.new(actual_rrdatas))
-                  puts " * [#{ns} -> #{rrset.name}] success. (acctual=#{actual_rrdatas.inspect})"
+                  puts " * [#{ns} -> #{rrset.name}] success. (actual=#{actual_rrdatas.inspect})"
                   sleep 1
                   break
                 else
-                  puts " * [#{ns} -> #{rrset.name}] failed. (required=#{required_rrdatas.to_a.inspect}, but acctual=#{actual_rrdatas.inspect})"
+                  puts " * [#{ns} -> #{rrset.name}] failed. (required=#{required_rrdatas.to_a.inspect}, but actual=#{actual_rrdatas.inspect})"
                   sleep 5
                 end
               end

--- a/lib/acmesmith/challenge_responders/google_cloud_dns.rb
+++ b/lib/acmesmith/challenge_responders/google_cloud_dns.rb
@@ -93,7 +93,7 @@ module Acmesmith
           Resolv::DNS.open(:nameserver => Resolv.getaddresses(ns)) do |dns|
             dns.timeouts = 5
             change.additions.each do |rrset|
-              required_rrdatas = Set.new(rrset.rrdatas.map{|rrdata| rrdata.gsub(/(\A"|"\z)/, '') })
+              required_rrdatas = Set.new(rrset.rrdatas)
               loop do
                 resources = dns.getresources(rrset.name, Resolv::DNS::Resource::IN::TXT)
                 actual_rrdatas = resources.map(&:data)
@@ -152,7 +152,7 @@ module Acmesmith
           domain = canonicalize(domain)
           name = [challenge.record_name, domain].join('.')
           type = challenge.record_type
-          data = "\"#{challenge.record_content}\""
+          data = challenge.record_content
 
           {
             name: name,

--- a/lib/acmesmith/challenge_responders/google_cloud_dns.rb
+++ b/lib/acmesmith/challenge_responders/google_cloud_dns.rb
@@ -11,6 +11,10 @@ module Acmesmith
         type == 'dns-01'
       end
 
+      def cap_respond_all?
+        true
+      end
+
       def initialize(config)
         @config = config
         @scope = "https://www.googleapis.com/auth/ndev.clouddns.readwrite"
@@ -32,6 +36,29 @@ module Acmesmith
         @project_id = @config[:project_id]
       end
 
+      def respond_all(*domain_and_challenges)
+        challenges_by_zone_names = domain_and_challenges.group_by{ |domain, challenge|
+          domain = canonicalize(domain)
+          find_managed_zone(domain).name
+        }
+
+        challenges_by_zone_names.each do |zone_name, dcs|
+          changes =  ## TODO: not implemented yet
+          # dcs.each do |domain, challenge|
+          #   p [zone_name, domain, challenge.record_type, challenge.record_content]
+          # end
+        end
+      end
+
+      def cleanup_all(*domain_and_challenges)
+        challenges_by_zone_names = domain_and_challenges.group_by{ |domain, challenge|
+          domain = canonicalize(domain)
+          find_managed_zone(domain).name
+        }
+        ## TODO: not implemented yet
+      end
+
+      ## TODO: remove this method
       def respond(domain, challenge)
         puts "=> Responding challenge dns-01 for #{domain} in #{self.class.name}"
 
@@ -48,6 +75,7 @@ module Acmesmith
         wait_for_sync(zone_name, domain, challenge, change_id)
       end
 
+      ## TODO: remove this method
       def cleanup(domain, challenge)
         domain = canonicalize(domain)
         zone_name = find_managed_zone(domain).name

--- a/lib/acmesmith/challenge_responders/google_cloud_dns.rb
+++ b/lib/acmesmith/challenge_responders/google_cloud_dns.rb
@@ -94,10 +94,16 @@ module Acmesmith
             dns.timeouts = 5
             change.additions.each do |rrset|
               required_rrdatas = Set.new(rrset.rrdatas)
+
+              deletion = change.deletions.find{|_deletion| _deletion.name == rrset.name && _deletion.type == rrset.type }
+              if deletion
+                required_rrdatas -= Set.new(deletion.rrdatas)
+              end
+
               loop do
                 resources = dns.getresources(rrset.name, Resolv::DNS::Resource::IN::TXT)
                 actual_rrdatas = resources.map(&:data)
-                if required_rrdatas == Set.new(actual_rrdatas)
+                if required_rrdatas.subset?(Set.new(actual_rrdatas))
                   puts " * [#{ns} -> #{rrset.name}] success. (acctual=#{actual_rrdatas.inspect})"
                   sleep 1
                   break

--- a/lib/acmesmith/challenge_responders/google_cloud_dns.rb
+++ b/lib/acmesmith/challenge_responders/google_cloud_dns.rb
@@ -93,7 +93,7 @@ module Acmesmith
           Resolv::DNS.open(:nameserver => Resolv.getaddresses(ns)) do |dns|
             dns.timeouts = 5
             change.additions.each do |rrset|
-              required_rrdatas = Set.new(rrset.rrdatas)
+              required_rrdatas = Set.new(rrset.rrdatas.map{|rrdata| rrdata.gsub(/(\A"|"\z)/, '') })
 
               deletion = change.deletions.find{|_deletion| _deletion.name == rrset.name && _deletion.type == rrset.type }
               if deletion
@@ -158,7 +158,7 @@ module Acmesmith
           domain = canonicalize(domain)
           name = [challenge.record_name, domain].join('.')
           type = challenge.record_type
-          data = challenge.record_content
+          data = "\"#{challenge.record_content}\""
 
           {
             name: name,


### PR DESCRIPTION
Supported [acmesmith v2.0.0 feature](https://github.com/sorah/acmesmith/blob/master/CHANGELOG.md#new-features)

> ChallengeResponders::Base now allows to respond many challenges at once

for acmesmith-google-cloud-dns.